### PR TITLE
feat: initial CI for templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# All unset values default to none
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+permissions: read-all
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn build
+
+      - name: (Windows) Setup and test templates
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          Set-Location template
+          Get-ChildItem -Directory | ForEach-Object {
+            Push-Location $_.Name
+            yarn install
+            yarn fmt:check
+            yarn build
+            yarn test
+            Pop-Location
+          }
+
+      - name: (non-Windows) Setup and test templates
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: |
+          cd template
+          for d in */; do
+            pushd "$d"
+            yarn install
+            yarn fmt:check
+            yarn build
+            yarn test
+            popd
+          done


### PR DESCRIPTION
Closes #18.

Until either #20 or #13 is merged it seems like we cannot run `create-tact` non-interactively. See the description in #20 for details.

Hence, I've added simple install-build steps for `create-tact` and install-fmt-build-test steps for each of the templates available.